### PR TITLE
fix(qrcode): Replace the invalid liantu with NetEase loft qrcode

### DIFF
--- a/src/components/widget/PageInfo.vue
+++ b/src/components/widget/PageInfo.vue
@@ -64,7 +64,7 @@
         var temp = new Image()
         temp.src = `${Config.VIEW_PATH}` + urlInfo.params.key
         console.log('src', temp.src)
-        return 'https://www.liantu.com/api.php?text=' + encodeURIComponent(temp.src)
+        return `https://www.lofter.com/genBitmaxImage?url=${encodeURIComponent(temp.src)}&h=200&w=200`
       },
       outUrl: function () {
         var urlInfo = common.parseURL(window.location.href)

--- a/src/dialog/d-Preview.vue
+++ b/src/dialog/d-Preview.vue
@@ -124,7 +124,7 @@
       qrUrl: function () {
         var temp = new Image()
         temp.src = this.preUrl
-        return 'https://www.liantu.com/api.php?text=' + encodeURIComponent(temp.src)
+        return `https://www.lofter.com/genBitmaxImage?url=${encodeURIComponent(temp.src)}&h=200&w=200`
       },
     },
     methods: {


### PR DESCRIPTION
1. 临时方案：替换 Liantu QRCode 为网易 loft QRCode(后者已稳定运行多年)；
2. 思考：可以前端通过库来自生成 QRCode，减少对外部的依赖。