### PR TITLE
修正 html 标签名不合法的隐患问题

### DIFF
--- a/src/assets/data/empty.json
+++ b/src/assets/data/empty.json
@@ -11,7 +11,7 @@
     },
     "props": {},
     "child": [{
-      "id": "truck/richtextj0n4g65h",
+      "id": "ymm-truck-richtextj0n4g65h",
       "type": "truck/richtext",
       "label": "初次见面，请移除我",
       "visible": true,

--- a/src/components/Node.vue
+++ b/src/components/Node.vue
@@ -421,7 +421,7 @@
         this.slots = this.calcSlots(component, this.nodeInfo.props)
         let type = this.nodeInfo.type
         // 如果有label（用户设置 || getbasenode设置 || 这里设置）保留，否则从component配置对象获取，否则用id
-        that.$set(that.info, 'label', that.info.label ? that.info.label : that.info.id.replace(type, (component && component.label) || type))
+        that.$set(that.info, 'label', that.info.label ? that.info.label : that.info.id.replace(`ymm-${type.replace(/\//g, '-')}`, (component && component.label) || type))
         that.$set(that.info, 'stack', (() => {
           // 设置过了
           if (typeof that.info.stack === 'boolean') return that.info.stack

--- a/src/extend/Util.js
+++ b/src/extend/Util.js
@@ -62,7 +62,7 @@ function getBaseNode (node) {
   if (!node.id) return
   useComponent(node.id)
   var info = {
-    id: node.name,
+    id: `ymm-${node.name.replace(/\//g, '-')}`,
     type: node.name,
     label: node.label,
     version: node.version,
@@ -83,7 +83,7 @@ function getBaseNode (node) {
       top: '0px'
     }, node.style)
   }
-  var idCache = Object.keys(window.$_nodecomponents || {}).concat([node.name])
+  var idCache = Object.keys(window.$_nodecomponents || {}).concat([info.id])
   info = modifyNodeId(info, idCache)
   if (info.label) info.label = info.id.replace(node.id, info.label) // 给label添加id
   return info


### PR DESCRIPTION
码良原始状况是使用 `xxx/yyy` 这样的名字创建 Vue 组件，这种名字是不合法的 html tag name，vue 在开发环境下也会有警告，为消除警告和隐患，建议使用合法的 html tag name